### PR TITLE
Default to running native, not docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,13 +13,16 @@ RUN apt-get update && \
 
 USER $NB_UID
 
+# RUN pip install jupyter_contrib_nbextensions
+# RUN jupyter contrib nbextension install --user
+# RUN jupyter nbextension enable spellchecker/main
+
 # Fetch and build ngn/k
 RUN git clone https://codeberg.org/ngn/k.git && \
     cd k && \
-    git rev-parse --short HEAD > VER && \
-    sed 's/repl.prompt:," "/repl.prompt:"ngnk> "/' repl.k>repl.k.new && \
-    mv repl.k.new repl.k && \
     make k-libc
+
+ENV NGNKDIR=/home/jovyan/k
 
 # Install the flit tool; a simplified python package manager
 RUN pip install flit

--- a/README-docker.md
+++ b/README-docker.md
@@ -1,0 +1,30 @@
+# A Jupyter kernel for ngn/k
+
+NOTE: This is alpha quality at best.
+
+This is a jupyter kernel for [ngn/k](https://codeberg.org/ngn/k), derived from the [bash_kernel](https://github.com/takluyver/bash_kernel).
+
+To use the kernel with docker, build and run the docker image:
+
+    docker build -t ngnkern .
+
+which fetches the most bleeding edge of ngn/k and builds it from source. Note that ngn/k is a moving target.
+
+Run container as `ngnk`
+
+    docker run --name ngnk --rm -p 8888:8888 -v ./notebooks ngnkern
+
+or, better, as
+
+    docker run --name ngnk --rm -p 8888:8888 -v "$(pwd)"/notebooks:/home/jovyan/notebooks ngnkern
+
+sharing a directory `./notebooks` on the host as `/home/jovyan/notebooks` in the container for persistence.
+
+If everything worked as intended, you should be given a URL to open.
+
+To open a shell on the running container, you can do
+
+    docker exec -it ngnk /bin/bash
+
+For details of how this works, see the Jupyter docs on [wrapper kernels](http://jupyter-client.readthedocs.org//en/latest/wrapperkernels.html), and
+`pexpect`'s docs on the [replwrap module](http://pexpect.readthedocs.org/en/latest/api/replwrap.html).

--- a/README.md
+++ b/README.md
@@ -4,41 +4,23 @@ NOTE: This is alpha quality at best.
 
 This is a jupyter kernel for [ngn/k](https://codeberg.org/ngn/k), derived from the [bash_kernel](https://github.com/takluyver/bash_kernel).
 
-This kernel is designed to run in a docker container, which fetches the most bleeding edge of ngn/k and builds it from source. Note that ngn/k is a moving target.
+To use the kernel with docker, see the file README-Docker.md
 
-If you want to run this kernel 'natively' instead of in Docker, you need to do two things:
+## Install
 
-Change the line
+Ensure that you have a working build of ngn/k. This kernel expects that you have built the `k-libc` version. Set the environment variable `NGNKDIR`
 
-    cmd = '/home/jovyan/k/k-libc /home/jovyan/k/repl.k'
+    export NGNKDIR="/your/path/to/k/dir"
 
-in `NgnkKernel` to reflect your ngn/k installation location.
+so that the executable can be reached as `/your/path/to/k/dir/k-libc`.
 
-Change the prompt in `repl.k`:
+Now run
 
-    repl.prompt:"ngnk> "
+    `python install.py --sys-prefix`
 
-This is so that `pexpect` has something to look for. See the `Dockerfile`.
+and start the notebook server
 
-To use the kernel, build and run the docker image:
-
-    docker build -t ngnkern .
-
-Run container as `ngnk`
-
-    docker run --name ngnk --rm -p 8888:8888 -v ./notebooks ngnkern
-
-or, better, as
-
-    docker run --name ngnk --rm -p 8888:8888 -v "$(pwd)"/notebooks:/home/jovyan/notebooks ngnkern
-
-sharing a directory `./notebooks` on the host as `/home/jovyan/notebooks` in the container for persistence.
-
-If everything worked as intended, you should be given a URL to open.
-
-To open a shell on the running container, you can do
-
-    docker exec -it ngnk /bin/bash
+    jupyter notebook
 
 For details of how this works, see the Jupyter docs on [wrapper kernels](http://jupyter-client.readthedocs.org//en/latest/wrapperkernels.html), and
 `pexpect`'s docs on the [replwrap module](http://pexpect.readthedocs.org/en/latest/api/replwrap.html).

--- a/ngnk_kernel/kernel.py
+++ b/ngnk_kernel/kernel.py
@@ -3,6 +3,7 @@ Derived from bash_kernel (https://github.com/takluyver/bash_kernel)
 """
 
 from ipykernel.kernelbase import Kernel
+import os
 from pexpect import replwrap, EOF
 
 import re
@@ -10,6 +11,7 @@ import re
 __version__ = '0.1'
 
 version_pat = re.compile(r'version (\d+(\.\d+)+)')
+NGNKDIR = os.environ['NGNKDIR']
 
 
 class IREPLWrapper(replwrap.REPLWrapper):
@@ -18,6 +20,7 @@ class IREPLWrapper(replwrap.REPLWrapper):
                  cmd_or_spawn,
                  orig_prompt,
                  prompt_change,
+                 new_prompt,
                  extra_init_cmd=None,
                  line_output_callback=None):
         self.line_output_callback = line_output_callback
@@ -25,6 +28,7 @@ class IREPLWrapper(replwrap.REPLWrapper):
                                       cmd_or_spawn,
                                       orig_prompt,
                                       prompt_change,
+                                      new_prompt,
                                       extra_init_cmd=extra_init_cmd)
 
     def _expect_prompt(self, timeout=-1):
@@ -47,7 +51,7 @@ class IREPLWrapper(replwrap.REPLWrapper):
 class NgnkKernel(Kernel):
     implementation = 'ngnk_kernel'
     implementation_version = __version__
-    cmd = '/home/jovyan/k/k-libc /home/jovyan/k/repl.k'
+    cmd = f'{NGNKDIR}/k-libc {NGNKDIR}/repl.k'
     prompt = u'ngnk> '
 
     @property
@@ -75,8 +79,9 @@ class NgnkKernel(Kernel):
     def _start_ngnk(self):
         self.ngnkwrapper = IREPLWrapper(
             self.cmd,
-            self.prompt,
-            None,
+            ' ',  # Prompt defaults to single space
+            'repl.prompt:"ngnk> "',  # Command to change prompt
+            self.prompt,  # New prompt after change
             line_output_callback=self.process_output)
 
     def process_output(self, output):


### PR DESCRIPTION
As `ngn/k` now builds nicely on macos, tweak to run locally, and make this the default for the README.